### PR TITLE
Adding 12refactor gem for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ group :doc do
   gem 'sdoc', require: false
 end
 
+gem 'rails_12factor', group: :production
+
 group :development, :test do
   gem 'annotate', ">=2.6.0"
   gem 'capybara', '~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: git://github.com/zalapeach/badges_engine.git
-  revision: bc0d6a5849d5123e4050610e54b7bfca084da1b9
+  revision: 57b95abd2b1c0798162356ea852d2fd8f27e3d43
   specs:
     badges_engine (0.0.1)
       carrierwave
@@ -110,7 +110,7 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
-    excon (0.37.0)
+    excon (0.38.0)
     execjs (2.2.1)
     fabrication (2.11.3)
     faker (1.4.1)
@@ -148,7 +148,7 @@ GEM
     httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    i18n (0.6.9)
+    i18n (0.6.11)
     inflecto (0.0.2)
     ipaddress (0.8.0)
     jbuilder (1.5.3)
@@ -222,6 +222,9 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.0.4)
       sprockets-rails (~> 2.0.0)
+    rails_12factor (0.0.2)
+      rails_serve_static_assets
+      rails_stdout_logging
     rails_best_practices (1.15.4)
       activesupport
       awesome_print
@@ -232,6 +235,8 @@ GEM
       json
       require_all
       ruby-progressbar
+    rails_serve_static_assets (0.0.2)
+    rails_stdout_logging (0.0.3)
     railties (4.0.4)
       actionpack (= 4.0.4)
       activesupport (= 4.0.4)
@@ -306,7 +311,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.39)
+    tzinfo (0.3.40)
     uglifier (2.5.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -355,6 +360,7 @@ DEPENDENCIES
   pry-nav
   pry-rails (~> 0.3.2)
   rails (= 4.0.4)
+  rails_12factor
   rails_best_practices
   rspec-rails (~> 2.14.2)
   sass-rails (~> 4.0.0)


### PR DESCRIPTION
By default Rails 4 will not serve your assets. To enable this functionality you need to go into config/application.rb and add this line:

```
config.serve_static_assets = true
```

Alternatively you can achieve the same result by including the rails_12factor gem in your Gemfile:

```
gem 'rails_12factor', group: :production
```
