### PR TITLE
Load bamboo users when a rake db:seed is ran

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require 'rake'
+
 data = YAML.load_file('config/dataseeds/awards.yml')
 
 data.each do |info|
@@ -13,3 +15,6 @@ data.each do |info|
   value.description = info['description']
   value.save
 end
+
+Rake::Task['bamboo:sync_users'].invoke
+


### PR DESCRIPTION
It's easier to get the app ready if we load the Bamboo users on db:seed.
