### PR TITLE
Remove dashboard move

### DIFF
--- a/app/assets/stylesheets/modules/user-edit.sass
+++ b/app/assets/stylesheets/modules/user-edit.sass
@@ -1,5 +1,6 @@
-.adjust-dashboard
+.user-adjust-dashboard
   margin-left: 15px
+
 .user-container
   background: $white
 

--- a/app/views/users/my_badges.html.haml
+++ b/app/views/users/my_badges.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-md-12.adjust-dashboard
+  .col-md-12.user-adjust-dashboard
     .span12.badges
       %header.badges-header-container
         %h3.badges-header


### PR DESCRIPTION
This pull request remove the little jump of the dashboard when clicking "Check all my badges" and "Back to my dashboard" 
- Add a left-margin to set the correct position and avoid the visual jump when clicking the links 
