### PR TITLE
Redirect to the user's details page after sign in successfully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
+  def after_sign_in_path_for(resource)
+    resource.is_a?(User) ? user_path(current_user) : super
+  end
+
   private
 
   def admin_emails

--- a/spec/features/badges/edit_spec.rb
+++ b/spec/features/badges/edit_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 feature 'badges' do
   background do
     login_with_oauth
+    visit root_path
     User.first.update_attributes(is_admin: true)
     click_link 'Sign in'
     click_link 'Admin Power'

--- a/spec/features/badges/level/create_spec.rb
+++ b/spec/features/badges/level/create_spec.rb
@@ -5,6 +5,7 @@ feature 'Level' do
 
   background do
     login_with_oauth
+    visit root_path
     User.first.update_attributes(is_admin: true)
     click_link 'Sign in'
     click_link 'Admin Power'

--- a/spec/features/home/home_page_spec.rb
+++ b/spec/features/home/home_page_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 feature 'Home' do
-  background { visit root_path }
+  background do
+    visit root_path
+  end
 
   scenario 'User can see welcome message' do
     expect(page).to have_content 'Welcome to'
@@ -9,18 +11,15 @@ feature 'Home' do
 
   scenario 'User can sign in' do
     login_with_oauth
-    click_link 'Sign in'
     expect(page).to have_content 'Summary'
   end
 
   scenario 'User click on logo from landing page without login' do
-    click_link('Sign in')
     expect(page).to have_content 'Welcome to'
   end
 
   scenario 'User click on logo from landing page logged in' do
     login_with_oauth
-    click_link('Sign in')
     expect(page).to have_content 'Summary'
   end
 end

--- a/spec/features/user/edit_spec.rb
+++ b/spec/features/user/edit_spec.rb
@@ -11,7 +11,6 @@ feature "Edit profile information" do
     background do
       visit root_path
       login_with_oauth
-      click_link 'Sign in'
       click_link 'Account'
     end
 
@@ -34,7 +33,6 @@ feature "Edit profile information" do
     background do
       login_with_oauth
       User.first.update_attributes(is_admin: true)
-      click_link 'Sign in'
       click_link 'Account'
     end
 

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -13,7 +13,6 @@ feature 'User profile information' do
   background do
     visit root_path
     login_with_oauth
-    click_link 'Sign in'
   end
 
   scenario 'Users can see profile information' do


### PR DESCRIPTION
Fix the case in which you have to click on the sign in button twice.