### PR TITLE
Chore/improve badges page performance

### DIFF
--- a/app/assets/stylesheets/modules/badge.sass
+++ b/app/assets/stylesheets/modules/badge.sass
@@ -76,3 +76,4 @@
 .badge-unknown
   +grayscale_filter(100%)
   transform: translateZ(0)
+  opacity: 0.5

--- a/app/assets/stylesheets/modules/badge.sass
+++ b/app/assets/stylesheets/modules/badge.sass
@@ -9,12 +9,12 @@
   &:nth-of-type("#{ $columns }n")
     border-right: none
 
-= filter($pixels)
-  -moz-filter: blur($pixels)
-  -ms-filter: blur($pixels)
-  -o-filter: blur($pixels)
-  -webkit-filter: blur($pixels)
-  filter: blur($pixels)
+= grayscale_filter($pixels)
+  -moz-filter: grayscale($pixels)
+  -ms-filter: grayscale($pixels)
+  -o-filter: grayscale($pixels)
+  -webkit-filter: grayscale($pixels)
+  filter: grayscale($pixels)
 
 = transition($transition)
   -moz-transition: $transition
@@ -74,6 +74,5 @@
   padding: 10px 0
 
 .badge-unknown
-  +filter(5px)
-  opacity: 0.3
+  +grayscale_filter(100%)
   transform: translateZ(0)

--- a/app/assets/stylesheets/modules/badge.sass
+++ b/app/assets/stylesheets/modules/badge.sass
@@ -8,8 +8,6 @@
   width: $width
   &:nth-of-type("#{ $columns }n")
     border-right: none
-  img
-    position: relative
 
 = filter($pixels)
   -moz-filter: blur($pixels)
@@ -31,20 +29,19 @@
 .badge-6-col
   +badges_container(16.66%, 6)
   .badge-info
-    top: -14px
+    transform: translateY(-14px)
     &:hover
-      top: -152px
+      transform: translateY(-152px)
 
 .badge-info
   cursor: pointer
   position: relative
-  top: 0
-  transition: top 0.5s linear
+  transition: transform 0.5s linear
   &:hover
-    top: -138px
+    transform: translateY(-138px)
     .badge-earned-icon
-      display: none
-    .badge-description, .badge-details-link
+      opacity: 0
+    .badge-description
       opacity: 1
 
 .badge-earned-icon
@@ -62,6 +59,7 @@
   opacity: 0
   overflow: hidden
   transition: opacity 1s
+  transform: translateZ(0)
 
 .badge-details-link
   background-color: rgba(255, 255, 255, 0.9)
@@ -69,8 +67,6 @@
   display: block
   padding: 13px 0 5px
   text-decoration: underline
-  transition: opacity 1s
-  opacity: 0
 
 .badge-name
   background-color: rgba(255, 255, 255, 0.5)
@@ -79,5 +75,5 @@
 
 .badge-unknown
   +filter(5px)
-  +transition(all 1s ease)
   opacity: 0.3
+  transform: translateZ(0)

--- a/app/assets/stylesheets/modules/badge.sass
+++ b/app/assets/stylesheets/modules/badge.sass
@@ -33,16 +33,18 @@
     &:hover
       transform: translateY(-152px)
 
-.badge-info
+.badge-box
   cursor: pointer
-  position: relative
-  transition: transform 0.5s linear
+
   &:hover
-    transform: translateY(-138px)
+    .badge-info
+      transform: translateY(-152px)
     .badge-earned-icon
       opacity: 0
-    .badge-description
-      opacity: 1
+
+.badge-info
+  position: relative
+  transition: transform 0.4s linear
 
 .badge-earned-icon
   background: image_url('sprite-badges.png') -45px -1425px no-repeat
@@ -56,9 +58,7 @@
 .badge-description
   background-color: rgba(255, 255, 255, 0.9)
   height: 100px
-  opacity: 0
   overflow: hidden
-  transition: opacity 1s
   transform: translateZ(0)
 
 .badge-details-link

--- a/app/assets/stylesheets/modules/badges.sass
+++ b/app/assets/stylesheets/modules/badges.sass
@@ -74,6 +74,7 @@
   padding: 16px
   position: relative
   text-align: center
+  transform: translateZ(0)
 
 .badges-footer-badge
   @extend .badges-footer

--- a/app/views/shared/_badge.html.haml
+++ b/app/views/shared/_badge.html.haml
@@ -1,4 +1,4 @@
-%div{ class: define_badge_column }
+%div.badge-box{ class: define_badge_column }
   = image_tag badge.image_url, { class: unknown_image?(badge) }
   .badge-info
     = badge_earn_icon(badge)


### PR DESCRIPTION
- Make badge's animation smoother
![kardex](https://cloud.githubusercontent.com/assets/1796036/6476319/f4a5e198-c1d9-11e4-8886-9fee786a6e6e.gif)
![kardex_imp](https://cloud.githubusercontent.com/assets/1796036/6476320/fa2eb3c4-c1d9-11e4-8342-a61025fe40e4.gif)

- Use a grayscale filter
- Make the badge's description appear when hovering the whole badge's box
