### PR TITLE
Fix regression UI issue with badge's thumbnail on user page

### DIFF
--- a/app/assets/stylesheets/modules/badge.sass
+++ b/app/assets/stylesheets/modules/badge.sass
@@ -28,17 +28,21 @@
 
 .badge-6-col
   +badges_container(16.66%, 6)
-  .badge-info
-    transform: translateY(-14px)
+
+  &.badge-box
+    .badge-info
+      transform: translateY(-14px)
+
     &:hover
-      transform: translateY(-152px)
+      .badge-info
+        transform: translateY(-152px)
 
 .badge-box
   cursor: pointer
 
   &:hover
     .badge-info
-      transform: translateY(-152px)
+      transform: translateY(-138px)
     .badge-earned-icon
       opacity: 0
 


### PR DESCRIPTION
It fixes this:
![img](https://www.evernote.com/shard/s10/sh/c30db064-1d46-471e-998f-9a2e7ef7bdb6/25d4319af8d1bfcd4c7c5c3605bad69c/deep/0/Kardex-Crowdint.png)