### PR TITLE
Redirect to sign in page on unauthorized access

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+require 'kardex_failure_app'
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -239,6 +241,10 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+
+  config.warden do |manager|
+    manager.failure_app = KardexFailureApp
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/lib/kardex_failure_app.rb
+++ b/lib/kardex_failure_app.rb
@@ -1,0 +1,13 @@
+class KardexFailureApp < Devise::FailureApp
+  def redirect_url
+    root_path
+  end
+
+  def respond
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+end

--- a/spec/features/user/authentication_spec.rb
+++ b/spec/features/user/authentication_spec.rb
@@ -1,13 +1,18 @@
 require 'spec_helper'
 
 feature "User Authentication" do
-  background do
-    login_with_oauth
-    User.first.update_attributes(is_admin: true)
-    login_with_oauth
+  let(:user) { Fabricate :user }
+
+  scenario 'User is redirected to the sign in page if visit a path without being authenticated' do
+    visit user_path(user)
+    expect(page).to have_content 'Welcome to'
+    expect(page).to have_content 'You need to sign in or sign up before continuing.'
   end
 
   scenario "User is able to signing successfully" do
+    login_with_oauth
+    User.first.update_attributes(is_admin: true)
+    login_with_oauth
     visit admin_root_path
     expect(page).to have_content 'Admin settings'
   end


### PR DESCRIPTION
Redirect to the sign in page instead of just showing the message "You need to sign in or sign up before continuing." when the user is not signed in. 